### PR TITLE
Allow extensions to declare flag exclusions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,13 @@ branches:
 python:
   - pypy
   - pypy3
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 
 install: travis_retry .travis/install.sh
 
-script: tox
+script: pytest
 
 notifications:
   irc:

--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,7 @@ element matching the following, all optional:
 * ``uses`` — declare the tags that must be evaluated prior to this extension, but aren't hard requirements
 * ``first`` — declare that this extension is a dependency of all other non-first extensions
 * ``last`` — declare that this extension depends on all other non-last extensions
+* ``excludes`` — declare tags that must not be present in other plugins for this one to be usable
 
 
 6. Version History

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -10,16 +10,15 @@ from marrow.package.cache import PluginCache
 
 from pytest import main as pytest
 from coverage.cmdline import main as coverage
-from pip import main as pip
-from pytest_cagoule.cmdline import main as cagoule
+from pip._internal import main as pip
 
 
 class TestPluginCache(TestCase):
-	candidates = ('py.test', 'coverage', 'pip', 'cagoule')
+	candidates = ('py.test', 'coverage', 'pip')
 	
 	def test__cache__loads_expected_objects(self):
 		cache = PluginCache('console_scripts')
-		for candidate, obj in zip(self.candidates, (pytest, coverage, pip, cagoule)):
+		for candidate, obj in zip(self.candidates, (pytest, coverage, pip)):
 			assert cache[candidate] is obj
 	
 	def test__cache__attribute_access(self):

--- a/test/test_host.py
+++ b/test/test_host.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 
 from marrow.package.host import ExtensionManager
 
-from pip import main as pip
+from pip._internal import main as pip
 
 
 class BadExtension(object):
@@ -39,6 +39,10 @@ class GExtension(object):
 class HExtension(object):
 	provides = ('h', )
 	needs = ('g', )
+
+class XExtension(object):
+	provides = ('x', )
+	excludes = ('a', )
 
 
 class TestExtensionManager(TestCase):
@@ -97,3 +101,9 @@ class TestExtensionManager(TestCase):
 		
 		with pytest.raises(LookupError):
 			manager.order([GExtension(), HExtension()])
+	
+	def test__extension__exclusion(self):
+		manager = ExtensionManager('console_scripts')
+		
+		with pytest.raises(RuntimeError):
+			manager.order([AExtension(), XExtension()])


### PR DESCRIPTION
Implementation of marrow/WebCore#177.  Not _quite_ as proposed, as with this implementation extensions can exclude themselves (preventing use as a "singleton" indicator).