### PR TITLE
Armour against "protected" attribute and element access, transform exceptions.

### DIFF
--- a/marrow/package/cache.py
+++ b/marrow/package/cache.py
@@ -27,4 +27,9 @@ class PluginCache(defaultdict):
 	def __getattr__(self, name):
 		"""Proxy attribute access through to the dictionary."""
 		
-		return self[name]
+		try:
+			return self[name]
+		except KeyError:
+			pass
+		
+		raise AttributeError()

--- a/marrow/package/host.py
+++ b/marrow/package/host.py
@@ -23,6 +23,8 @@ class PluginManager:
 	plugins:List[Plugin]
 	named:PluginCache
 	
+	__wrapped__ = None  # Python decorator protocol bypass.
+	
 	def __init__(self, namespace:str, folders:Iterable[str]=None):
 		assert check_argument_types()
 		
@@ -77,7 +79,13 @@ class PluginManager:
 	
 	def __getattr__(self, name:str):
 		if name.startswith('_'): raise AttributeError()
-		return self.named[name]
+		
+		try:
+			return self.named[name]
+		except IndexError:
+			pass
+		
+		raise AttributeError()
 	
 	def __getitem__(self, name:str):
 		if name.startswith('_'): raise KeyError()

--- a/marrow/package/host.py
+++ b/marrow/package/host.py
@@ -76,9 +76,11 @@ class PluginManager:
 			yield plugin
 	
 	def __getattr__(self, name:str):
+		if name.startswith('_'): raise AttributeError()
 		return self.named[name]
 	
 	def __getitem__(self, name:str):
+		if name.startswith('_'): raise KeyError()
 		return self.named[name]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ setup_requires =
 	setuptools-scm >= 1.7.0
 
 install_requires =
-	typeguard ~=2.3.0,<4.0
+	typeguard
 
 tests_require =
 	pytest


### PR DESCRIPTION
Introspection within modern language versions attempts to access `__wrapped__` directly, so provide a default value for this. Additionally, generally protect against underscore-prefixed plugin access, and correctly transform `IndexError` into `AttributeError` within the attribute access code path.